### PR TITLE
Change site id on Digiteka's iframe

### DIFF
--- a/Lib/Embera/Providers/Digiteka.php
+++ b/Lib/Embera/Providers/Digiteka.php
@@ -18,6 +18,17 @@ class Digiteka extends \Embera\Adapters\Service
 
         return (preg_match('~ultimedia\.com/(?:[^ ]+)/id/(?:[^ ]+)~i', $this->url));
     }
+
+    /** inline {@inheritdoc}
+      * @TODO: This function needs to be removed when Digiteka will change their oembed return
+     */
+    protected function modifyResponse(array $response = array())
+    {
+        if (!empty($response['html'])) {
+            $response['html'] = preg_replace('/mdtk\/([0-9]+)\/src/', 'mdtk/01357940/src', $response['html']);  
+        }
+        return $response;
+    }
 }
 
 ?>


### PR DESCRIPTION
We replace generic id by our id on iframe.
This is only temporary when Digiteka will made change on their oembed return we will be able to remove this.

Zube : https://zube.io/20minutes/storm/c/2407
Github issue: https://github.com/20minutes/storm/issues/69