### PR TITLE
Update Facebook and Instagram API URL

### DIFF
--- a/Lib/Embera/Providers/Facebook.php
+++ b/Lib/Embera/Providers/Facebook.php
@@ -128,11 +128,11 @@ class Facebook extends \Embera\Adapters\Service
     public function getInfo()
     {
         if ($this->urlMatchesPattern($this->videoPatterns)) {
-            $this->apiUrl = 'https://www.facebook.com/plugins/video/oembed.json/';
+            $this->apiUrl = 'https://graph.facebook.com/v8.0/oembed_video';
         } elseif ($this->urlMatchesPattern($this->postPatterns)) {
-            $this->apiUrl = 'https://www.facebook.com/plugins/post/oembed.json/';
+            $this->apiUrl = 'https://graph.facebook.com/v8.0/oembed_post';
         } else {
-            $this->apiUrl = 'https://www.facebook.com/plugins/page/oembed.json/';
+            $this->apiUrl = 'https://graph.facebook.com/v8.0/oembed_page';
         }
 
         return parent::getInfo();

--- a/Lib/Embera/Providers/Instagram.php
+++ b/Lib/Embera/Providers/Instagram.php
@@ -19,7 +19,7 @@ namespace Embera\Providers;
 class Instagram extends \Embera\Adapters\Service
 {
     /** inline {@inheritdoc} */
-    protected $apiUrl = 'https://api.instagram.com/oembed?format=json';
+    protected $apiUrl = 'https://graph.facebook.com/v8.0/instagram_oembed';
 
     /** inline {@inheritdoc} */
     protected function validateUrl()


### PR DESCRIPTION
Facebook (and instagram which belongs to facebook) changed their oembed API. We are adapting our providers configuration.

Zube story: https://zube.io/20minutes/vega/c/14427 